### PR TITLE
removing trailing 0 from cnfgen calls

### DIFF
--- a/code/graph_vary.py
+++ b/code/graph_vary.py
@@ -10,8 +10,8 @@ import networkx as nx
 def create_sat_problem(filename, problem, graph_generator, k):
     while True:
         nx.write_gml(graph_generator(), 'tmp.gml')
-        subprocess.call(['cnfgen', '-q', '-o', 'tmp.cnf', problem, '--input', 'tmp.gml', str(k)] +
-                        (['0'] if problem == 'kcolor' else []))
+        subprocess.call(['cnfgen', '-q', '-o', 'tmp.cnf', problem, '--input', 'tmp.gml', str(k)])
+
         try:
             subprocess.check_call(['minisat', 'tmp.cnf'], stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as ex:

--- a/code/kcolor.py
+++ b/code/kcolor.py
@@ -8,7 +8,7 @@ import subprocess
 
 def create_sat_problem(filename, n, p, k):
     while True:
-        subprocess.call(['cnfgen', '-q', '-o', 'tmp.cnf', 'kcolor', '--gnp', str(n), str(p), str(k), '0'])
+        subprocess.call(['cnfgen', '-q', '-o', 'tmp.cnf', 'kcolor', '--gnp', str(n), str(p), str(k)])
         try:
             subprocess.check_call(['minisat', 'tmp.cnf'], stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as ex:


### PR DESCRIPTION
Hi, I'm using cnfgen installed from pip. If I try to run a data generation script for kcolor (e.g. scripts/generate_kcolor.sh) I get error messages from cnfgen: "c ERROR: unrecognized arguments: 0". 

The problem is solved if the trailing 0 argument is removed from cnfgen calls.